### PR TITLE
Ignore pycache & DB files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 env/
+*.sqlite3
+__pycache__/


### PR DESCRIPTION
Updates `gitignore` to ignore Python cache & the sqlite database, to avoid conflicts.